### PR TITLE
Update content names

### DIFF
--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -13,6 +13,7 @@ namespace FHIRcastSandbox.Model {
         public string UID { get; set; }
 
         [BindRequired]
+        [URLNameOverride("hub.callback")]
         public Uri Callback { get; set; }
 
         [BindRequired]
@@ -20,14 +21,16 @@ namespace FHIRcastSandbox.Model {
         public SubscriptionMode? Mode { get; set; }
 
         [BindRequired]
+        [URLNameOverride("hub.topic")]
         public string Topic { get; set; }
 
         [BindRequired]
+        [URLNameOverride("hub.events")]
         public string[] Events { get; set; }
     }
 
     public abstract class SubscriptionWithLease : SubscriptionBase {
-        [ModelBinder(Name = "lease_seconds")]
+        [URLNameOverride("hub.lease_seconds")]
         public int? LeaseSeconds { get; set; }
 
         [BindNever, JsonIgnore]
@@ -36,12 +39,14 @@ namespace FHIRcastSandbox.Model {
 
     public class Subscription : SubscriptionWithLease {
         [BindRequired]
+        [URLNameOverride("hub.secret")]
         public string Secret { get; set; }
         [BindNever, JsonIgnore]
         public string HubURL { get; set; }
     }
 
     public class SubscriptionCancelled : SubscriptionBase {
+        [URLNameOverride("hub.reason")]
         public string Reason { get; set; }
     }
 

--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -16,6 +16,7 @@ namespace FHIRcastSandbox.Model {
         public Uri Callback { get; set; }
 
         [BindRequired]
+        [URLNameOverride("hub.mode")]
         public SubscriptionMode? Mode { get; set; }
 
         [BindRequired]
@@ -45,12 +46,13 @@ namespace FHIRcastSandbox.Model {
     }
 
     public class SubscriptionVerification : SubscriptionWithLease {
+        [URLNameOverride("hub.challenge")]
         public string Challenge { get; set; }
     }
 
     public enum SubscriptionMode {
-        Subscribe,
-        Unsubscribe,
+        subscribe,
+        unsubscribe,
     }
 
     public class SubscriptionComparer : IEqualityComparer<Subscription> {
@@ -64,14 +66,30 @@ namespace FHIRcastSandbox.Model {
     }
 
     public class Notification : ModelBase {
+        [JsonProperty(PropertyName = "timestamp")]
         public DateTime Timestamp { get; set; }
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
+        [JsonProperty(PropertyName = "event")]
         public NotificationEvent Event { get; } = new NotificationEvent();
     }
 
     public class NotificationEvent {
+        [JsonProperty(PropertyName = "hub.topic")]
         public string Topic { get; set; }
+        [JsonProperty(PropertyName = "hub.event")]
         public string Event { get; set; }
+        [JsonProperty(PropertyName = "context")]
         public object[] Context { get; set; }
+    }
+
+    public class URLNameOverride : Attribute
+    {
+        public URLNameOverride(string value)
+        {
+            this.Value = value;
+        }
+
+        public string Value { get; set; }
     }
 }

--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -9,7 +9,7 @@ namespace FHIRcastSandbox.Model {
     public abstract class SubscriptionBase : ModelBase {
         public static IEqualityComparer<Subscription> DefaultComparer => new SubscriptionComparer();
 
-        [BindRequired]
+        [BindNever]
         public string UID { get; set; }
 
         [BindRequired]

--- a/Hub/Core/SubscriptionCallback.cs
+++ b/Hub/Core/SubscriptionCallback.cs
@@ -24,11 +24,6 @@ namespace FHIRcastSandbox.Core {
         }
 
         private string GetFieldName(PropertyInfo property) {
-            /* var modelBinder = property.GetCustomAttribute<ModelBinder>(); */
-            /* var name = modelBinder?.Name; */
-            /* if (!string.IsNullOrEmpty(name)) { */
-            /*     return name; */
-            /* } */
             var attr = property.GetCustomAttribute<URLNameOverride>();
             if (attr == null) { return property.Name.ToLower(); }
             else { return attr.Value; }

--- a/Hub/Core/SubscriptionCallback.cs
+++ b/Hub/Core/SubscriptionCallback.cs
@@ -29,8 +29,9 @@ namespace FHIRcastSandbox.Core {
             /* if (!string.IsNullOrEmpty(name)) { */
             /*     return name; */
             /* } */
-
-            return property.Name.ToLower();
+            var attr = property.GetCustomAttribute<URLNameOverride>();
+            if (attr == null) { return property.Name.ToLower(); }
+            else { return attr.Value; }
         }
     }
 }

--- a/Hub/Rules/ValidateSubscriptionJob.cs
+++ b/Hub/Rules/ValidateSubscriptionJob.cs
@@ -16,7 +16,7 @@ namespace FHIRcastSandbox.Rules {
         }
 
         public async Task Run(Subscription subscription, bool simulateCancellation) {
-            if (subscription.Mode == SubscriptionMode.Subscribe) {
+            if (subscription.Mode == SubscriptionMode.subscribe) {
                 HubValidationOutcome validationOutcome = simulateCancellation ? HubValidationOutcome.Canceled : HubValidationOutcome.Valid;
                 var validationResult = await this.validator.ValidateSubscription(subscription, validationOutcome);
                 if (validationResult == ClientValidationOutcome.Verified) {
@@ -25,7 +25,7 @@ namespace FHIRcastSandbox.Rules {
                 } else {
                     this.logger.LogInformation($"Not adding unverified subscription: {subscription}.");
                 }
-            } else if (subscription.Mode == SubscriptionMode.Unsubscribe) {
+            } else if (subscription.Mode == SubscriptionMode.unsubscribe) {
                 this.subscriptions.RemoveSubscription(subscription);
             }
         }

--- a/WebSubClient/Controllers/WebSubClientController.cs
+++ b/WebSubClient/Controllers/WebSubClientController.cs
@@ -65,7 +65,8 @@ namespace FHIRcastSandbox.Controllers {
 
             internalModel = model;
             var httpClient = new HttpClient();
-            var response = httpClient.PostAsync(this.Request.Scheme + "://" + this.Request.Host + "/api/hub/notify", new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, "application/json")).Result;
+            //var response = httpClient.PostAsync(this.Request.Scheme + "://" + this.Request.Host + "/api/hub/notify", new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, "application/json")).Result;
+            var response = httpClient.PostAsync(this.Request.Scheme + "://localhost:5000/api/hub/notify", new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, "application/json")).Result;
 
             return View("WebSubClient", model);
         }
@@ -139,7 +140,7 @@ namespace FHIRcastSandbox.Controllers {
                 UID = subUID,
                 Callback = new Uri(this.Request.Scheme + "://" + this.Request.Host + "/client/" + subUID),
                 Events = events.Split(";", StringSplitOptions.RemoveEmptyEntries),
-                Mode = SubscriptionMode.Subscribe,
+                Mode = SubscriptionMode.subscribe,
                 Secret = secret,
                 LeaseSeconds = 3600,
                 Topic = topic
@@ -176,7 +177,7 @@ namespace FHIRcastSandbox.Controllers {
             this.logger.LogDebug($"Unsubscribing subscription {subscriptionId}");
             if (!activeSubs.ContainsKey(subscriptionId)) { return View("WebSubClient", internalModel); }
             Subscription sub = activeSubs[subscriptionId];
-            sub.Mode = SubscriptionMode.Unsubscribe;
+            sub.Mode = SubscriptionMode.unsubscribe;
 
             var httpClient = new HttpClient();
             var result = await httpClient.PostAsync(sub.HubURL,


### PR DESCRIPTION
Update the names of the properties and content we send in the uri and the notification post to match the specs. They should be lowercase and in some cases include "hub."