### PR TITLE
Send HMAC 256 digest with notifications

### DIFF
--- a/Common/HmacDigest.cs
+++ b/Common/HmacDigest.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace FHIRcastSandbox.Rules {
+    public class HmacDigest {
+        public string CreateDigest(string key, string payload) {
+            var byteKey = System.Text.Encoding.UTF8.GetBytes(key);
+            using (var hmacHasher = new System.Security.Cryptography.HMACSHA256(byteKey)) {
+                var digest = hmacHasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload));
+                return BitConverter.ToString(digest).Replace("-", "").ToLower();
+            }
+        }
+
+        public string CreateHubSignature(string key, string payload) {
+            return $"sha256={this.CreateDigest(key, payload)}";
+        }
+    }
+}

--- a/Hub/Rules/Notifications.cs
+++ b/Hub/Rules/Notifications.cs
@@ -19,6 +19,9 @@ namespace FHIRcastSandbox.Rules {
             var str = Newtonsoft.Json.JsonConvert.SerializeObject(notification);
             var content = new StringContent(str);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            var hubSignature = new HmacDigest().CreateHubSignature(subscription.Secret, str);
+            content.Headers.Add("X-Hub-Signature", hubSignature);
             var client = new HttpClient();
             var response = await client.PostAsync(subscription.Callback, content);
 

--- a/Tests/HmacDigestTests.cs
+++ b/Tests/HmacDigestTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Xunit;
+
+namespace FHIRcastSandbox.Rules {
+    public class HmacDigestTests {
+        [Fact]
+        public void CreateDigest_KeyAndPayload_CreateCorrectDigest_Test() {
+            // Arange
+            var key = "key";
+            var payload = "The quick brown fox jumps over the lazy dog";
+
+            // Act
+            var result = new HmacDigest().CreateDigest(key, payload);
+
+            // Assert
+            Assert.Equal("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8", result);
+        }
+
+        [Fact]
+        public void CreateHubSignature_KeyAndPayload_CreateSignatureForSha256_Test() {
+            // Arange
+            var key = "key";
+            var payload = "The quick brown fox jumps over the lazy dog";
+
+            // Act
+            var result = new HmacDigest().CreateHubSignature(key, payload);
+
+            // Assert
+            Assert.Equal("sha256=f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8", result);
+        }
+    }
+}


### PR DESCRIPTION
According to the specification, a HMAC should be sent in the `X-Hub-Signature` HTTP header when the hub is sending notifications to clients. This PR implements a sha256 HMAC digest for all notifications.