### PR TITLE
lease seconds was not passed to the hub due to underscore in the encoded URL

### DIFF
--- a/Common/Model/HttpSubscription.cs
+++ b/Common/Model/HttpSubscription.cs
@@ -10,7 +10,7 @@ namespace FHIRcastSandbox.Model.Http {
                 $"&hub.topic={source.Topic}" +
                 $"&hub.secret={source.Secret}" +
                 $"&hub.events={string.Join(",", source.Events)}" +
-                $"&hub.lease_seconds={source.LeaseSeconds}";
+                $"&hub.leaseseconds={source.LeaseSeconds}";
 
             StringContent httpcontent = new StringContent(
                     content,

--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -41,7 +41,7 @@ namespace FHIRcastSandbox.Model {
     }
 
     public abstract class SubscriptionWithLease : SubscriptionBase {
-        [URLNameOverride("hub.lease_seconds")]
+        [URLNameOverride("hub.leaseseconds")]
         public int? LeaseSeconds { get; set; }
 
         [BindNever, JsonIgnore]

--- a/WebSubClient/Rules/HubSubscriptions.cs
+++ b/WebSubClient/Rules/HubSubscriptions.cs
@@ -18,7 +18,7 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
                                 $"&hub.topic={subscription.Topic}" +
                                 $"&hub.secret={subscription.Secret}" +
                                 $"&hub.events={string.Join(",", subscription.Events)}" +
-                                $"&hub.lease_seconds={subscription.LeaseSeconds}";
+                                $"&hub.leaseseconds={subscription.LeaseSeconds}";
 
             StringContent httpcontent = new StringContent(
                     content,
@@ -43,7 +43,7 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
                     $"&hub.topic={subscription.Topic}" +
                     $"&hub.secret={subscription.Secret}" +
                     $"&hub.events={string.Join(",", subscription.Events)}" +
-                    $"&hub.lease_seconds={subscription.LeaseSeconds}";
+                    $"&hub.leaseseconds={subscription.LeaseSeconds}";
 
             StringContent httpContent = new StringContent(
                     content,


### PR DESCRIPTION
lease seconds was not passed to the hub due to underscore in the encoded URL