### PR TITLE
Consolidate Subscription Classes

### DIFF
--- a/Common/Model/HttpSubscription.cs
+++ b/Common/Model/HttpSubscription.cs
@@ -3,7 +3,8 @@ using FHIRcastSandbox.Model;
 
 namespace FHIRcastSandbox.Model.Http {
     public static class SubscriptionExtensions {
-        public static HttpContent CreateHttpContent(this Subscription source) {
+        public static HttpContent CreateHttpContent(this Subscription source)
+        {
 
             string content = $"hub.callback={source.Callback}" +
                 $"&hub.mode={source.Mode}" +

--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -9,110 +9,74 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace FHIRcastSandbox.Model {
-    public abstract class SubscriptionBase : ModelBase {
+
+
+    public class Subscription
+    {
         public static IEqualityComparer<Subscription> DefaultComparer => new SubscriptionComparer();
 
-        [BindRequired]
         [URLNameOverride("hub.callback")]
         public string Callback { get; set; }
 
-        [BindRequired]
         [URLNameOverride("hub.mode")]
         public SubscriptionMode? Mode { get; set; }
 
-        [BindRequired]
         [URLNameOverride("hub.topic")]
         public string Topic { get; set; }
 
-        [BindRequired]
         [URLNameOverride("hub.events")]
-        [ModelBinder(typeof(EventsArrayModelBinder))]
         public string[] Events { get; set; }
 
-        /// <summary>
-        /// Gets a subscriber-unique ID of this subscription.
-        /// </summary>
-        /// <returns>An ID that is unique to the subscriber creating the subscription.</returns>
-        public string GetUniqueId() {
-            return GetSubscriptionId(this.Topic, this.Callback);
-        }
-
-        public static string GetSubscriptionId(string topic, string callback) {
-            return BitConverter.ToString(SHA256.Create().ComputeHash(System.Text.Encoding.UTF8.GetBytes((topic ?? "") + (callback ?? ""))));
-        }
-    }
-
-    public abstract class SubscriptionWithLease : SubscriptionBase {
-        [URLNameOverride("hub.lease_seconds")]
-        [FromForm (Name = "lease_seconds")]
-        public int? LeaseSeconds { get; set; }
-
-        [BindNever, JsonIgnore]
-        public TimeSpan? Lease => this.LeaseSeconds.HasValue ? TimeSpan.FromSeconds(this.LeaseSeconds.Value) : (TimeSpan?)null;
-    }
-
-    public class Subscription : SubscriptionWithLease {
-        [BindRequired]
         [URLNameOverride("hub.secret")]
         public string Secret { get; set; }
 
-        [BindNever, JsonIgnore]
-        [JSONSerializationAttribue(SubscriptionObjectUses.Request)]
-        public HubURL HubURL { get; set; }
+        [URLNameOverride("hub.lease_seconds")]
+        [FromForm(Name = "lease_seconds")]
+        public int? LeaseSeconds { get; set; }
 
-        public static Subscription CreateNewSubscription(string subscriptionUrl, string topic, string[] events, string callback) {
-            var rngCsp = new RNGCryptoServiceProvider();
-            var buffer = new byte[32];
-            rngCsp.GetBytes(buffer);
-            var secret = BitConverter.ToString(buffer).Replace("-", "");
-            var subscription = new Subscription()
-            {
-                Callback = callback,
-                Events = events,
-                Mode = SubscriptionMode.subscribe,
-                Secret = secret,
-                LeaseSeconds = 3600,
-                Topic = topic
-            };
-            subscription.HubURL = new HubURL() { URL = subscriptionUrl };
+        [JsonIgnore]
+        public TimeSpan? Lease => this.LeaseSeconds.HasValue ? TimeSpan.FromSeconds(this.LeaseSeconds.Value) : (TimeSpan?)null;
 
-            return subscription;
-        }
-
-        public bool IsInterestedInNotification(Notification notification) {
-            return this.Events.Any(e => e == notification.Event.Event)
-                && notification.Event.Topic == this.Topic;
-        }
-    }
-
-    public class SubscriptionWithHubURL : Subscription
-    {
-        public SubscriptionWithHubURL(Subscription baseSubscription)
-        {
-            this.Callback = baseSubscription.Callback;
-            this.Events = baseSubscription.Events;
-            this.HubURL = baseSubscription.HubURL;
-            this.LeaseSeconds = baseSubscription.LeaseSeconds;
-            this.Mode = baseSubscription.Mode;
-            this.Secret = baseSubscription.Secret;
-            this.Topic = baseSubscription.Topic;
-        }
-
-        [BindNever]
-        public HubURL HubURL { get; set; }
-    }
-
-    public class SubscriptionCancelled : SubscriptionBase {
-        [URLNameOverride("hub.reason")]
-        public string Reason { get; set; }
-    }
-
-    public class SubscriptionVerification : SubscriptionWithLease {
         [URLNameOverride("hub.challenge")]
         public string Challenge { get; set; }
 
         [URLNameOverride("hub.reason")]
         public string Reason { get; set; }
+
+        public HubURL HubURL { get; set; }
+
+        /// <summary>
+        /// Gets a subscriber-unique ID of this subscription.
+        /// </summary>
+        /// <returns>An ID that is unique to the subscriber creating the subscription.</returns>
+        public string GetUniqueId()
+        {
+            return GetSubscriptionId(this.Topic, this.Callback);
+        }
+
+        public static string GetSubscriptionId(string topic, string callback)
+        {
+            return BitConverter.ToString(SHA256.Create().ComputeHash(System.Text.Encoding.UTF8.GetBytes((topic ?? "") + (callback ?? ""))));
+        }
+
+        public bool IsInterestedInNotification(Notification notification)
+        {
+            return this.Events.Any(e => e == notification.Event.Event)
+                && notification.Event.Topic == this.Topic;
+        }
+
+        public bool ValidModelState(SubscriptionModelStates state)
+        {
+            //State dependent validations
+
+            //State independent validation
+            if ((this.Callback == null) || (this.Mode == null) || (this.Topic == null) || (this.Events == null))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 
     public enum SubscriptionMode {
@@ -121,12 +85,15 @@ namespace FHIRcastSandbox.Model {
         denied,
     }
 
-    public class SubscriptionComparer : IEqualityComparer<Subscription> {
-        public bool Equals(Subscription sub1, Subscription sub2) {
+    public class SubscriptionComparer : IEqualityComparer<Subscription>
+    {
+        public bool Equals(Subscription sub1, Subscription sub2)
+        {
             return sub1.Callback == sub2.Callback && sub1.Topic == sub2.Topic;
         }
 
-        public int GetHashCode(Subscription subscription) {
+        public int GetHashCode(Subscription subscription)
+        {
             return subscription.Callback.GetHashCode() ^ subscription.Topic.GetHashCode();
         }
     }
@@ -168,13 +135,14 @@ namespace FHIRcastSandbox.Model {
         public string[] HTTPHeaders { get; set; }
     }
 
-    public class DynamicContractResolver : DefaultContractResolver
+    //https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_IContractResolver.htm
+    public class SubscriptionContractResolver : DefaultContractResolver
     {
-        private readonly SubscriptionObjectUses _subscriptionObjectUse;
+        private readonly SubscriptionModelStates _subscriptionModelStates;
 
-        public DynamicContractResolver(SubscriptionObjectUses use)
+        public SubscriptionContractResolver(SubscriptionModelStates use)
         {
-            _subscriptionObjectUse = use;
+            _subscriptionModelStates = use;
         }
 
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
@@ -184,10 +152,10 @@ namespace FHIRcastSandbox.Model {
 
             foreach (JsonProperty prop in properties)
             {
-                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(typeof(JSONSerializationAttribue), false);
-                foreach (JSONSerializationAttribue att in attributes)
+                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(typeof(SubscriptionConditionallySerialize), false);
+                foreach (SubscriptionConditionallySerialize att in attributes)
                 {
-                    if (att.SubscriptionUses.Contains(_subscriptionObjectUse))
+                    if (att.ModelStates.Contains(_subscriptionModelStates))
                     {
                         updatedProperties.Add(prop);
                         break;
@@ -195,52 +163,23 @@ namespace FHIRcastSandbox.Model {
                 }
             }
 
-            properties = updatedProperties;
-
-            // only serializer properties that start with the specified character
-            //properties =
-            //    properties.Where(p => p.PropertyName.StartsWith(_startingWithChar.ToString())).ToList();
-            //properties = properties.Where(p => p.AttributeProvider.GetAttributes(typeof(JSONSerializationAttribue,false).))
-            //properties = properties.Where(p => p.AttributeProvider.GetAttributes<JSONSerializationAttribue>(typeof(JSONSerializationAttribue), false).Select(x =>  //.ToList<JSONSerializationAttribue>().Where(x => x.SubscriptionUses.Contains(_subscriptionObjectUse));
-
-            return properties;
-        }
-    }
-
-    public class ShouldSerializeContractResolver : DefaultContractResolver
-    {
-        public new static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();
-
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
-        {
-            JsonProperty property = base.CreateProperty(member, memberSerialization);
-
-            if (property.DeclaringType == typeof(Subscription))
-            {
-                property.ShouldSerialize =
-                    instance =>
-                    {
-                        // Employee e = (Employee)instance;
-                        return true; //e.Manager != e;
-                    };
-            }
-
-            return property;
+            return updatedProperties;
         }
     }
 
     #region Property Attribute
-    public class JSONSerializationAttribue : Attribute
-    {
-        public JSONSerializationAttribue(params SubscriptionObjectUses[] subscriptionObjectUses)
-        {
-            this.SubscriptionUses = subscriptionObjectUses;
-        }
 
-        public SubscriptionObjectUses[] SubscriptionUses { get; private set; }
+    public class SubscriptionConditionallySerialize : Attribute
+    {
+        public SubscriptionModelStates[] ModelStates { get; private set; }
+
+        public SubscriptionConditionallySerialize(params SubscriptionModelStates[] modelStates)
+        {
+            this.ModelStates = modelStates;
+        }
     }
 
-    public enum SubscriptionObjectUses
+    public enum SubscriptionModelStates
     {
         Request,
         Verification,

--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -8,7 +8,8 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace FHIRcastSandbox.Model {
+namespace FHIRcastSandbox.Model
+{
 
 
     public class Subscription
@@ -77,9 +78,30 @@ namespace FHIRcastSandbox.Model {
 
             return true;
         }
+
+        public static Subscription CreateNewSubscription(string subscriptionUrl, string topic, string[] events, string callback)
+        {	        /// <summary>
+            var rngCsp = new RNGCryptoServiceProvider();	        /// Gets a subscriber-unique ID of this subscription.
+            var buffer = new byte[32];	        /// </summary>
+            rngCsp.GetBytes(buffer);	        /// <returns>An ID that is unique to the subscriber creating the subscription.</returns>
+            var secret = BitConverter.ToString(buffer).Replace("-", "");
+            var subscription = new Subscription()
+            {
+                Callback = callback,
+                Events = events,
+                Mode = SubscriptionMode.subscribe,
+                Secret = secret,
+                LeaseSeconds = 3600,
+                Topic = topic
+            };
+            subscription.HubURL = new HubURL() { URL = subscriptionUrl };
+
+            return subscription;
+        }
     }
 
-    public enum SubscriptionMode {
+    public enum SubscriptionMode
+    {
         subscribe,
         unsubscribe,
         denied,
@@ -98,7 +120,8 @@ namespace FHIRcastSandbox.Model {
         }
     }
 
-    public class Notification : ModelBase {
+    public class Notification : ModelBase
+    {
         [JsonProperty(PropertyName = "timestamp")]
         public DateTime Timestamp { get; set; }
         [JsonProperty(PropertyName = "id")]
@@ -107,7 +130,8 @@ namespace FHIRcastSandbox.Model {
         public NotificationEvent Event { get; } = new NotificationEvent();
     }
 
-    public class NotificationEvent {
+    public class NotificationEvent
+    {
         [ModelBinder(Name = "hub.topic")]
         [JsonProperty(PropertyName = "hub.topic")]
         public string Topic { get; set; }
@@ -120,8 +144,10 @@ namespace FHIRcastSandbox.Model {
         public object[] Context { get; set; }
     }
 
-    public class URLNameOverride : Attribute {
-        public URLNameOverride(string value) {
+    public class URLNameOverride : Attribute
+    {
+        public URLNameOverride(string value)
+        {
             this.Value = value;
         }
 

--- a/Hub/Controllers/HubController.cs
+++ b/Hub/Controllers/HubController.cs
@@ -32,20 +32,13 @@ namespace FHIRcastSandbox.Controllers {
         /// <param name="_cancel">if set to <c>true</c> simulate cancelling/denying the subscription by sending this to the callback url.</param>
         /// <returns></returns>
         [HttpPost]
-        public IActionResult Subscribe([FromForm]Subscription hub, bool _cancel = false) {
-            this.logger.LogDebug($"Model valid state is {this.ModelState.IsValid}");
-            foreach (var modelProperty in this.ModelState) {
-                if (modelProperty.Value.Errors.Count > 0) {
-                    for (int i = 0; i < modelProperty.Value.Errors.Count; i++) {
-                        this.logger.LogDebug($"Error found for {modelProperty.Key}: {modelProperty.Value.Errors[i].ErrorMessage}");
-                    }
-                }
-            }
-
+        public IActionResult Subscribe([FromForm]Subscription hub, bool _cancel = false)
+        {
             this.logger.LogDebug($"Subscription for 'received hub subscription': {Environment.NewLine}{hub}");
-
-            if (!this.ModelState.IsValid) {
-                return this.BadRequest(this.ModelState);
+            if (!hub.ValidModelState(SubscriptionModelStates.Request))
+            {
+                //TODO: Add error logging and an error message to the bad request
+                return this.BadRequest();
             }
 
             this.backgroundJobClient.Enqueue<ValidateSubscriptionJob>(job => job.Run(hub, _cancel));
@@ -58,7 +51,8 @@ namespace FHIRcastSandbox.Controllers {
         /// </summary>
         /// <returns>All active subscriptions.</returns>
         [HttpGet]
-        public IEnumerable<Subscription> GetSubscriptions() {
+        public IEnumerable<Subscription> GetSubscriptions()
+        {
             return this.subscriptions.GetActiveSubscriptions();
         }
 

--- a/Hub/Core/SubscriptionCallback.cs
+++ b/Hub/Core/SubscriptionCallback.cs
@@ -10,7 +10,8 @@ using System;
 
 namespace FHIRcastSandbox.Core {
     public class SubscriptionCallback {
-        public Uri GetCallbackUri(Subscription subscription, SubscriptionBase parameters) {
+        public Uri GetCallbackUri(Subscription subscription, Subscription parameters)
+        {
             var properties = parameters.GetType().GetProperties()
                 .Where(x => x.GetValue(parameters, null) != null)
                 .Select(x => this.GetFieldName(x) + "=" + HttpUtility.UrlEncode(x.GetValue(parameters, null).ToString()));

--- a/Hub/Rules/Notifications.cs
+++ b/Hub/Rules/Notifications.cs
@@ -13,7 +13,8 @@ namespace FHIRcastSandbox.Rules {
             this.logger = logger;
         }
 
-        public async Task<HttpResponseMessage> SendNotification(Notification notification, Subscription subscription) {
+        public async Task<HttpResponseMessage> SendNotification(Notification notification, Subscription subscription)
+        {
             this.logger.LogInformation($"Sending notification {notification} to callback {subscription.Callback}");
 
             var str = Newtonsoft.Json.JsonConvert.SerializeObject(notification);

--- a/Hub/Rules/SubscriptionValidator.cs
+++ b/Hub/Rules/SubscriptionValidator.cs
@@ -13,23 +13,24 @@ namespace FHIRcastSandbox.Rules {
             this.logger = logger;
         }
 
-        public async Task<ClientValidationOutcome> ValidateSubscription(Subscription subscription, HubValidationOutcome outcome) {
+        public async Task<ClientValidationOutcome> ValidateSubscription(Subscription subscription, HubValidationOutcome outcome)
+        {
             if (subscription == null) {
                 throw new ArgumentNullException(nameof(subscription));
             }
 
-            SubscriptionBase callbackParameters = null;
+            Subscription callbackParameters = null;
             if (outcome == HubValidationOutcome.Canceled) {
                 logger.LogDebug("Simulating canceled subscription.");
 
-                callbackParameters = new SubscriptionCancelled
+                callbackParameters = new Subscription
                 {
                     Reason = $"The subscription {subscription} was canceled for testing purposes.",
                 };
             } else {
                 logger.LogDebug("Verifying subscription.");
 
-                callbackParameters = new SubscriptionVerification
+                callbackParameters = new Subscription
                 {
                     // Note that this is not necessarily cryptographically random/secure.
                     Challenge = Guid.NewGuid().ToString("n"),
@@ -53,7 +54,7 @@ namespace FHIRcastSandbox.Rules {
                 return ClientValidationOutcome.NotVerified;
             }
             if (outcome == HubValidationOutcome.Valid) {
-                var challenge = ((SubscriptionVerification)callbackParameters).Challenge;
+                var challenge = callbackParameters.Challenge;
                 var responseBody = (await response.Content.ReadAsStringAsync());
                 if (responseBody != challenge) {
                     logger.LogInformation($"Callback result for verification request was not equal to challenge. Response body: '{responseBody}', Challenge: '{challenge}'.");

--- a/Hub/Rules/Subscriptions.cs
+++ b/Hub/Rules/Subscriptions.cs
@@ -14,11 +14,13 @@ namespace FHIRcastSandbox.Rules {
             this.logger = logger;
         }
 
-        public ICollection<Subscription> GetActiveSubscriptions() {
+        public ICollection<Subscription> GetActiveSubscriptions()
+        {
             return this.subscriptions;
         }
 
-        public ICollection<Subscription> GetSubscriptions(string topic, string notificationEvent) {
+        public ICollection<Subscription> GetSubscriptions(string topic, string notificationEvent)
+        {
             this.logger.LogDebug($"Finding subscriptions for topic: {topic} and event: {notificationEvent}");
             return this.subscriptions
                 .Where(x => x.Topic == topic)
@@ -31,12 +33,14 @@ namespace FHIRcastSandbox.Rules {
             return this.subscriptions.Where(x => x.Topic == sessionId).First();
         }
 
-        public void AddSubscription(Subscription subscription) {
+        public void AddSubscription(Subscription subscription)
+        {
             this.logger.LogInformation($"Adding subscription {subscription}.");
             this.subscriptions = this.subscriptions.Add(subscription);
         }
 
-        public void RemoveSubscription(Subscription subscription) {
+        public void RemoveSubscription(Subscription subscription)
+        {
             this.logger.LogInformation($"Removing subscription {subscription}.");
             this.subscriptions = this.subscriptions.Remove(subscription);
         }

--- a/Hub/Rules/ValidateSubscriptionJob.cs
+++ b/Hub/Rules/ValidateSubscriptionJob.cs
@@ -15,7 +15,8 @@ namespace FHIRcastSandbox.Rules {
             this.logger = logger;
         }
 
-        public async Task Run(Subscription subscription, bool simulateCancellation) {
+        public async Task Run(Subscription subscription, bool simulateCancellation)
+        {
             HubValidationOutcome validationOutcome = simulateCancellation ? HubValidationOutcome.Canceled : HubValidationOutcome.Valid;
             var validationResult = await this.validator.ValidateSubscription(subscription, validationOutcome);
             if (validationResult == ClientValidationOutcome.Verified)

--- a/WebSubClient/Controllers/CallbackController.cs
+++ b/WebSubClient/Controllers/CallbackController.cs
@@ -29,9 +29,13 @@ namespace FHIRcastSandbox.WebSubClient.Controllers
         /// <param name="verification">Hub's verification response to our subscription attempt</param>
         /// <returns></returns>
         [HttpGet("{connectionId}")]
-        public IActionResult SubscriptionVerification(string connectionId, [FromQuery] SubscriptionVerification hub) {
+        public IActionResult SubscriptionVerification(string connectionId, [FromQuery] Subscription hub) { 
             if (!this.config.GetValue("Settings:ValidateSubscriptionValidations", true)) {
                 return this.Content(hub.Challenge);
+            }
+            if (!hub.ValidModelState(SubscriptionModelStates.Verification))
+            {
+                //TODO: Error stuff for bad subscription
             }
 
             var verificationValidation = this.clientSubscriptions.ValidateVerification(connectionId, hub);

--- a/WebSubClient/Rules/ClientSubscriptions.cs
+++ b/WebSubClient/Rules/ClientSubscriptions.cs
@@ -9,10 +9,11 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
 
     public class ClientSubscriptions {
         //a connection can have multiple subscriptions so need the inner dictionary as well.
-        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, (SubscriptionInfo info, Subscription sub)>> subscriptions = 
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, (SubscriptionInfo info, Subscription sub)>> subscriptions =
             new ConcurrentDictionary<string, ConcurrentDictionary<string, (SubscriptionInfo info, Subscription sub)>>();
 
-        public void AddPendingSubscription(string connectionId, Subscription subscription) {
+        public void AddPendingSubscription(string connectionId, Subscription subscription)
+        {
             if (connectionId == null) {
                 throw new ArgumentNullException(nameof(connectionId));
             }
@@ -44,7 +45,7 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
             }          
         }
 
-        public SubscriptionWithHubURL[] GetClientSubscriptions(string connectionID)
+        public Subscription[] GetClientSubscriptions(string connectionID)
         {
             ConcurrentDictionary<string, (SubscriptionInfo info, Subscription sub)> subs;
             if (!this.subscriptions.TryGetValue(connectionID, out subs))
@@ -52,7 +53,7 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
                 //Throw error
             }
 
-            return subs.Values.Select(x => new SubscriptionWithHubURL(x.sub)).ToArray();
+            return subs.Values.Select(x => x.sub).ToArray();
         }
 
         public string[] GetSubscribedClients(Notification notification) {
@@ -66,15 +67,18 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
             return clients.ToArray();
         }
 
-        public Subscription GetSubscription(string subscriptionId, string topic) {
+        public Subscription GetSubscription(string subscriptionId, string topic)
+        {
             (_, var subscription) = this.GetExistingSubscription(subscriptionId, topic);
             return subscription;
         }
 
-        public SubscriptionVerificationValidation ValidateVerification(string clientConnectionId, SubscriptionVerification verification) {
+        public SubscriptionVerificationValidation ValidateVerification(string clientConnectionId, Subscription verification)
+        {
             var existingSubscription = this.GetExistingSubscription(clientConnectionId, verification.Topic);
 
-            if (existingSubscription.Equals(default((SubscriptionInfo, Subscription)))) {
+            if (existingSubscription.Equals(default((SubscriptionInfo, Subscription))))
+            {
                 return SubscriptionVerificationValidation.DoesNotExist;
             }
             if (existingSubscription.info.Status == SubscriptionStatus.Active) {
@@ -103,7 +107,8 @@ namespace FHIRcastSandbox.WebSubClient.Rules {
             this.subscriptions[clientConnectionId].TryRemove(topic, out _);
         }
 
-        private (SubscriptionInfo info, Subscription subscription) GetExistingSubscription(string clientConnectionId, string topic) {
+        private (SubscriptionInfo info, Subscription subscription) GetExistingSubscription(string clientConnectionId, string topic)
+        {
             return this.subscriptions[clientConnectionId][topic];
         }
     }

--- a/WebSubClient/Startup.cs
+++ b/WebSubClient/Startup.cs
@@ -15,7 +15,7 @@ namespace FHIRcastSandbox.WebSubClient {
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services) {
-            services.AddMvc().AddJsonOptions(options => options.SerializerSettings.ContractResolver = new ShouldSerializeContractResolver()); //.AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DynamicContractResolver());
+            services.AddMvc();
             services.AddSignalR();
             services.AddSingleton<ClientSubscriptions>();
             services.AddTransient<IHubSubscriptions, HubSubscriptions>();

--- a/WebSubClient/Startup.cs
+++ b/WebSubClient/Startup.cs
@@ -1,4 +1,5 @@
-﻿using FHIRcastSandbox.WebSubClient.Rules;
+﻿using FHIRcastSandbox.Model;
+using FHIRcastSandbox.WebSubClient.Rules;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -14,7 +15,7 @@ namespace FHIRcastSandbox.WebSubClient {
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services) {
-            services.AddMvc();
+            services.AddMvc().AddJsonOptions(options => options.SerializerSettings.ContractResolver = new ShouldSerializeContractResolver()); //.AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DynamicContractResolver());
             services.AddSignalR();
             services.AddSingleton<ClientSubscriptions>();
             services.AddTransient<IHubSubscriptions, HubSubscriptions>();

--- a/WebSubClient/Views/WebSubClient/WebSubClient.cshtml
+++ b/WebSubClient/Views/WebSubClient/WebSubClient.cshtml
@@ -201,17 +201,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @if (Model.SubscriptionsToHub != null)
-                                    {
-                                        @foreach (var item in Model.SubscriptionsToHub)
-                                        {
-                                            <tr>
-                                                <td>@item.Callback.ToString().Substring(0, item.Callback.ToString().LastIndexOf('/'))/{subscriptionId}</td>
-                                                <td>@item.Topic</td>
-                                                <td>@String.Join(",", item.Events)</td>
-                                            </tr>
-                                        }
-                                    }
+
                                 </tbody>
                             </table>
                         </fieldset>


### PR DESCRIPTION
Hey @lbergnehr and @wdvr, would you two be able to take a first pass at this pull request which aims at fixing issue #53. The changes are pretty substantial and I am not completely finished, but would like to get some approval of the general direction before going much further. 

The basic idea is that the Subscriptions class had 6 different class implementations mostly because the Subscription object has different properties depending on where we are at in the workflow. This was pretty confusing I think so I wanted to consolidate that. I put all the properties into a single Subscription class with the plan of performing the model validation ourselves rather than relying on the framework. We can define the different cases and what properties are required for them. Also for the JSON serialization (which also differed in the classes) I was hoping to use something like this [https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_IContractResolver.htm](url).

Let me know what you think and if you see any glaring issues with this approach.