### PR TITLE
fix merge issue with renaming of LeaseSeconds

### DIFF
--- a/Common/Model/Subscriptions.cs
+++ b/Common/Model/Subscriptions.cs
@@ -88,7 +88,7 @@ namespace FHIRcastSandbox.Model {
             this.Callback = baseSubscription.Callback;
             this.Events = baseSubscription.Events;
             this.HubURL = baseSubscription.HubURL;
-            this.LeaseSeconds = baseSubscription.LeaseSeconds;
+            this.Lease_Seconds = baseSubscription.Lease_Seconds;
             this.Mode = baseSubscription.Mode;
             this.Secret = baseSubscription.Secret;
             this.Topic = baseSubscription.Topic;


### PR DESCRIPTION
New tests by @johns397 also renamed Lease_Seconds - there is a json parse issue where the lease seconds where not mapped and read by the hub. This commit fixes one occurrence of the rename that was not updated since PR #52.

@wmaethner this is also something to check on #56 now.